### PR TITLE
Enhance context menu handling for images

### DIFF
--- a/src/ui/MenuService.ts
+++ b/src/ui/MenuService.ts
@@ -150,19 +150,22 @@ export class MenuService {
     async handleContextMenu(ev: MouseEvent | TouchEvent) {
         // For touch events, ignore multi-touch to prevent triggering during pinch zoom
         if ('touches' in ev && ev.touches.length > 1) return;
-        
+
         const img = findImageElement(ev.target);
         if (!img) return;
 
-        // Resolve the markdown view that owns this image element (supports multiple panes).
+        // IMPORTANT: Stop immediate propagation and prevent default
+        // This completely replaces Obsidian's native menu with PPI's menu
+        ev.stopImmediatePropagation();
+        ev.preventDefault();
+
+        // Resolve markdown view that owns this image element (supports multiple panes).
         const markdownView =
             findMarkdownViewForElement(this.plugin.app, img)
             ?? this.plugin.app.workspace.getActiveViewOfType(MarkdownView);
         if (!markdownView) return;
 
-        // Prevent default context menu
-        ev.preventDefault();
-
+        // Always use new Menu() to show only PPI's custom menu items
         const menu = new Menu();
         
         // Check if this is a remote image
@@ -214,12 +217,16 @@ export class MenuService {
             }
         }
 
-        // Position menu at event coordinates
-        const position = {
-            x: ev instanceof MouseEvent ? ev.pageX : ev.touches[0].pageX,
-            y: ev instanceof MouseEvent ? ev.pageY : ev.touches[0].pageY
-        };
-        menu.showAtPosition(position);
+        // Show menu - use showAtMouseEvent for desktop events, showAtPosition for touch
+        if (ev instanceof MouseEvent) {
+            menu.showAtMouseEvent(ev);
+        } else {
+            const position = {
+                x: ev.touches[0].pageX,
+                y: ev.touches[0].pageY
+            };
+            menu.showAtPosition(position);
+        }
     }
 
     /**

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -7,18 +7,27 @@ import { App, Editor, MarkdownView, TFile } from 'obsidian';
  */
 export function findImageElement(target: EventTarget | null): HTMLImageElement | null {
 	if (!target || !(target instanceof HTMLElement)) return null;
-	
+
 	// If target is already an image, return it
 	if (target instanceof HTMLImageElement) return target;
-	
+
+	// Special handling for edit-block-button: find associated image in the same embed container
+	if (target.matches('.edit-block-button')) {
+		const embedContainer = target.closest('.internal-embed');
+		if (embedContainer) {
+			return embedContainer.querySelector('img');
+		}
+		return null;
+	}
+
 	// Check if the target or its ancestors are related to images
-	const isImageContext = target.matches('.image-container, .image-embed, img, a.internal-embed[src*=".png"], a.internal-embed[src*=".jpg"], a.internal-embed[src*=".jpeg"], a.internal-embed[src*=".gif"], a.internal-embed[src*=".webp"], a.internal-embed[src*=".svg"]'); 
-	
+	const isImageContext = target.matches('.image-container, .image-embed, img, a.internal-embed[src*=".png"], a.internal-embed[src*=".jpg"], a.internal-embed[src*=".jpeg"], a.internal-embed[src*=".gif"], a.internal-embed[src*=".webp"], a.internal-embed[src*=".svg"]');
+
 	// Only search for img elements if we're in an image context
 	if (isImageContext) {
 		return target.querySelector('img');
 	}
-	
+
 	return null;
 }
 


### PR DESCRIPTION
Prevent double menus in Obsidian v1.12+ 
Fix #45 

BTW, this update handles "edit button" as well:
<img width="462" height="279" alt="Snipaste_2026-03-18_19-06-43" src="https://github.com/user-attachments/assets/59f18397-9e5e-40d6-85ba-631ee6a029b4" />
